### PR TITLE
Optimize PRNG by 1 byte

### DIFF
--- a/gameboy/src/rand.z80
+++ b/gameboy/src/rand.z80
@@ -38,7 +38,6 @@ rand::
   ld a,[hl-]
   ld c,a
   ld a,[hl-]
-  ld d,a
   ld e,[hl]
 
   ; Multiply by 0x01010101

--- a/gameboy/src/rand.z80
+++ b/gameboy/src/rand.z80
@@ -39,11 +39,10 @@ rand::
   ld c,a
   ld a,[hl-]
   ld d,a
-  ld a,[hl]
-  ld e,a
+  ld e,[hl]
 
   ; Multiply by 0x01010101
-  add d
+  add e
   ld d,a
   adc c
   ld c,a


### PR DESCRIPTION
Uses the symmetry of addition and the fact that one of the operands was already in `a` to load from `[hl]` directly to the target register.