### PR TITLE
Optimize audiosync_draw_row

### DIFF
--- a/gameboy/src/audiosync.z80
+++ b/gameboy/src/audiosync.z80
@@ -172,8 +172,8 @@ audiosync_draw_row:
   add 4
   ldh [dtr_t3],a
 
-  ld b,2
   ld hl,_SCRN0+32*2
+  ld bc,4
   ld de,12
 .rowloop:
   ldh a,[dtr_t0]
@@ -188,10 +188,7 @@ audiosync_draw_row:
   ldh a,[dtr_t3]
   ld [hl+],a
   ld [hl+],a
-  inc hl
-  inc hl
-  inc hl
-  inc hl
+  add hl,bc ; Skip over middle tiles
   ldh a,[dtr_t3]
   ld [hl+],a
   ld [hl+],a
@@ -204,8 +201,8 @@ audiosync_draw_row:
   ldh a,[dtr_t0]
   ld [hl+],a
   ld [hl+],a
-  add hl,de
-  dec b
+  add hl,de ; Go to next row
+  bit 7, l ; Check for _SCRN0+32*2 + 32*2
   jr nz,.rowloop
   ret
 


### PR DESCRIPTION
The function is smaller by 1 byte (4 `inc hl` removed, but 1 extra operand for `ld bc`, new `add hl, bc`, and prefix byte for `bit 7, l`).
Each iteration is faster by 5 cycles, with 1 extra cycle of overhead outside the loop.

Untested, but the logic hasn't been altered, so this should work just fine.