### PR TITLE
Fix Github Actions shallow cloning

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - name: Setup dependencies
         shell: bash
         run: |
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - name: Setup dependencies
         shell: bash
         run: |
@@ -61,6 +65,8 @@ jobs:
     container: devkitpro/devkitarm:latest
     steps:
       - uses: actions/checkout@master
+        with:
+          fetch-depth: 0
       - name: Setup dependencies
         shell: bash
         run: |


### PR DESCRIPTION
This pull request aims to fix Github Actions shallow cloning, which causes `git describe --tags` to not work, therefore not generating commit IDs and tag information for the NES and GB versions.

https://stackoverflow.com/questions/4916492/git-describe-fails-with-fatal-no-names-found-cannot-describe-anything/45993185#45993185